### PR TITLE
chore: 프로젝트 설정 변경

### DIFF
--- a/WordQuizDaily/WordQuizDaily.xcodeproj/project.pbxproj
+++ b/WordQuizDaily/WordQuizDaily.xcodeproj/project.pbxproj
@@ -618,12 +618,17 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = smith.WordQuizDaily;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -653,12 +658,17 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = smith.WordQuizDaily;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/WordQuizDaily/WordQuizDaily.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordQuizDaily/WordQuizDaily.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "92198c43ce1487718cd13ca010ae6fc57db37291b5ce7924c9e5333ce2fe8cdd",
+  "originHash" : "da8aba19ad30308e583600028276adf7800e14421ab5ada124b1c0b89b38f96a",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",


### PR DESCRIPTION
### 📋 PR 요약
이 PR은 앱스토어 배포 준비를 위한 프로젝트 설정 변경으로, 다음과 같은 주요 내용을 포함합니다:

### 🔄 주요 변경사항
마케팅 버전 업데이트: 1.0 → 1.0.1
플랫폼 지원 명확화: iPhone 전용 앱으로 설정
불필요한 플랫폼 지원 제거: Mac Catalyst, iPad 등 제거

### 🎯 목적
FCM 마이그레이션 및 알림 시스템 개선을 반영한 버전 업데이트
앱스토어 배포를 위한 최적화된 빌드 설정
iPhone 전용 앱으로 명확한 타겟팅
