### PR TITLE
feat: 다국어 지원 추가 (한국어, 영어, 일본어)

### DIFF
--- a/WordQuizDaily/WordQuizDaily.xcodeproj/project.pbxproj
+++ b/WordQuizDaily/WordQuizDaily.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		4A3E08482B822F2000848B7B /* NaverImageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3E08472B822F2000848B7B /* NaverImageData.swift */; };
 		4A3E084E2B82389800848B7B /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3E084D2B82389800848B7B /* HTTPMethod.swift */; };
 		4A3E08562B90893000848B7B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3E08552B90893000848B7B /* HomeViewModel.swift */; };
+		4A47DA132E2B809900E26A6E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4A47DA102E2B809900E26A6E /* Localizable.strings */; };
+		4A47DA142E2B809900E26A6E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4A47DA0B2E2B809900E26A6E /* InfoPlist.strings */; };
+		4A47DA182E2B818500E26A6E /* LocalizationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A47DA162E2B818500E26A6E /* LocalizationHelper.swift */; };
+		4A47DA192E2B818500E26A6E /* FormatterUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A47DA152E2B818500E26A6E /* FormatterUtils.swift */; };
 		4A4F06B82E26B88700EAB174 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 4A4F06B72E26B88700EAB174 /* Alamofire */; };
 		4A6323632B64DA6D004CA2DD /* QuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6323622B64DA6D004CA2DD /* QuizViewModel.swift */; };
 		4A6323652B66BA1F004CA2DD /* NaverNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6323642B66BA1F004CA2DD /* NaverNetwork.swift */; };
@@ -92,6 +96,15 @@
 		4A3E084D2B82389800848B7B /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		4A3E084F2B8267D800848B7B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4A3E08552B90893000848B7B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		4A47DA082E2B809900E26A6E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		4A47DA092E2B809900E26A6E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		4A47DA0A2E2B809900E26A6E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		4A47DA0C2E2B809900E26A6E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4A47DA0D2E2B809900E26A6E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4A47DA0E2E2B809900E26A6E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4A47DA0F2E2B809900E26A6E /* pseudo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pseudo; path = pseudo.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4A47DA152E2B818500E26A6E /* FormatterUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatterUtils.swift; sourceTree = "<group>"; };
+		4A47DA162E2B818500E26A6E /* LocalizationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationHelper.swift; sourceTree = "<group>"; };
 		4A6323622B64DA6D004CA2DD /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
 		4A6323642B66BA1F004CA2DD /* NaverNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaverNetwork.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -148,7 +161,9 @@
 		4A14C9482B6109E2004EE0AF /* WordQuizDaily */ = {
 			isa = PBXGroup;
 			children = (
+				4A47DA172E2B818500E26A6E /* Helpers */,
 				4A3E084F2B8267D800848B7B /* Info.plist */,
+				4A47DA122E2B809900E26A6E /* Resources */,
 				4A3A37122E26B16C008BF8EA /* Services */,
 				4A3E08522B84D4B200848B7B /* Network */,
 				4A14C9622B610F84004EE0AF /* Models */,
@@ -254,6 +269,32 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		4A47DA112E2B809900E26A6E /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				4A47DA0B2E2B809900E26A6E /* InfoPlist.strings */,
+				4A47DA102E2B809900E26A6E /* Localizable.strings */,
+			);
+			path = Localizations;
+			sourceTree = "<group>";
+		};
+		4A47DA122E2B809900E26A6E /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				4A47DA112E2B809900E26A6E /* Localizations */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		4A47DA172E2B818500E26A6E /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				4A47DA152E2B818500E26A6E /* FormatterUtils.swift */,
+				4A47DA162E2B818500E26A6E /* LocalizationHelper.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		87A96DACB312BCA20D3F552A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -322,11 +363,14 @@
 			};
 			buildConfigurationList = 4A14C9412B6109E2004EE0AF /* Build configuration list for PBXProject "WordQuizDaily" */;
 			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				ko,
+				ja,
+				pseudo,
 			);
 			mainGroup = 4A14C93D2B6109E2004EE0AF;
 			packageReferences = (
@@ -359,6 +403,8 @@
 			files = (
 				4A14C9512B6109E5004EE0AF /* Preview Assets.xcassets in Resources */,
 				4A14C94E2B6109E5004EE0AF /* Assets.xcassets in Resources */,
+				4A47DA132E2B809900E26A6E /* Localizable.strings in Resources */,
+				4A47DA142E2B809900E26A6E /* InfoPlist.strings in Resources */,
 				4A0192082E26AE4300E37532 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -383,6 +429,8 @@
 				4A14C95D2B610ABC004EE0AF /* HomeView.swift in Sources */,
 				4A3E084E2B82389800848B7B /* HTTPMethod.swift in Sources */,
 				4A3E08562B90893000848B7B /* HomeViewModel.swift in Sources */,
+				4A47DA182E2B818500E26A6E /* LocalizationHelper.swift in Sources */,
+				4A47DA192E2B818500E26A6E /* FormatterUtils.swift in Sources */,
 				4A14C95F2B610AD5004EE0AF /* QuizView.swift in Sources */,
 				4A14C9642B610F9C004EE0AF /* WordNetwork.swift in Sources */,
 				4A6323632B64DA6D004CA2DD /* QuizViewModel.swift in Sources */,
@@ -407,6 +455,30 @@
 			targetProxy = 4A0BD08D2B999A010019F565 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		4A47DA0B2E2B809900E26A6E /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4A47DA082E2B809900E26A6E /* ko */,
+				4A47DA092E2B809900E26A6E /* en */,
+				4A47DA0A2E2B809900E26A6E /* ja */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		4A47DA102E2B809900E26A6E /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4A47DA0C2E2B809900E26A6E /* ko */,
+				4A47DA0D2E2B809900E26A6E /* en */,
+				4A47DA0E2E2B809900E26A6E /* ja */,
+				4A47DA0F2E2B809900E26A6E /* pseudo */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		4A0BD0912B999A010019F565 /* Debug */ = {

--- a/WordQuizDaily/WordQuizDaily.xcodeproj/xcshareddata/xcschemes/WordQuizDaily.xcscheme
+++ b/WordQuizDaily/WordQuizDaily.xcodeproj/xcshareddata/xcschemes/WordQuizDaily.xcscheme
@@ -34,6 +34,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "ja"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -62,6 +63,10 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/WordQuizDaily/WordQuizDaily.xcodeproj/xcshareddata/xcschemes/WordQuizDaily.xcscheme
+++ b/WordQuizDaily/WordQuizDaily.xcodeproj/xcshareddata/xcschemes/WordQuizDaily.xcscheme
@@ -34,7 +34,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = "ja"
+      language = "ko"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WordQuizDaily/WordQuizDaily/ContentView.swift
+++ b/WordQuizDaily/WordQuizDaily/ContentView.swift
@@ -23,21 +23,21 @@ struct ContentView: View {
                 .environmentObject(quizViewModel)
                 .tag(1)
                 .tabItem {
-                    Label("Quiz", systemImage: "questionmark.circle")
+                    Label(LocalizedStringKey(LocalizationKeys.Tab.quiz), systemImage: "questionmark.circle")
                 }
             
             HomeView()
                 .environmentObject(homeViewModel)
                 .tag(2)
                 .tabItem {
-                    Label("Home", systemImage: "house.circle.fill")
+                    Label(LocalizedStringKey(LocalizationKeys.Tab.home), systemImage: "house.circle.fill")
                 }
             
             SettingView()
                 .environmentObject(notificationManager)
                 .tag(3)
                 .tabItem {
-                    Label("Setting", systemImage: "gearshape.fill")
+                    Label(LocalizedStringKey(LocalizationKeys.Tab.settings), systemImage: "gearshape.fill")
                 }
         }
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name("NavigateToQuiz"))) { _ in
@@ -54,4 +54,24 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .previewLocale("ko")
+}
+
+// MARK: - 다국어 프리뷰
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ContentView()
+                .previewLocale("ko")
+                .previewDisplayName("Korean")
+            
+            ContentView()
+                .previewLocale("en")
+                .previewDisplayName("English")
+            
+            ContentView()
+                .previewLocale("ja")
+                .previewDisplayName("Japanese")
+        }
+    }
 }

--- a/WordQuizDaily/WordQuizDaily/Helpers/FormatterUtils.swift
+++ b/WordQuizDaily/WordQuizDaily/Helpers/FormatterUtils.swift
@@ -170,7 +170,12 @@ struct FormatterUtils {
     /// - Parameter text: 원본 텍스트
     /// - Returns: 언어별 특수 포맷이 적용된 텍스트
     static func localizedSpecialFormat(text: String) -> String {
-        let currentLanguage = Locale.current.languageCode ?? "ko"
+        let currentLanguage: String
+        if #available(iOS 16, *) {
+            currentLanguage = Locale.current.language.languageCode?.identifier ?? "ko"
+        } else {
+            currentLanguage = Locale.current.languageCode ?? "ko"
+        }
         
         switch currentLanguage {
         case "ja":

--- a/WordQuizDaily/WordQuizDaily/Helpers/FormatterUtils.swift
+++ b/WordQuizDaily/WordQuizDaily/Helpers/FormatterUtils.swift
@@ -1,0 +1,245 @@
+//
+//  FormatterUtils.swift
+//  WordQuizDaily
+//
+//  Created on 2025-07-18.
+//  다국어 지원을 위한 포맷터 유틸리티
+//
+
+import Foundation
+
+// MARK: - 포맷터 유틸리티
+struct FormatterUtils {
+    
+    // MARK: - 날짜 포맷터
+    
+    /// 현재 로케일에 맞는 날짜 포맷터
+    static var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }
+    
+    /// 시간 포맷터
+    static var timeFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }
+    
+    /// 커스텀 날짜 포맷터
+    /// - Parameter format: 날짜 포맷 문자열
+    /// - Returns: 설정된 DateFormatter
+    static func customDateFormatter(format: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = format
+        return formatter
+    }
+    
+    /// 일본어 연호 지원 날짜 포맷터
+    static var japaneseDateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.calendar = Calendar(identifier: .japanese)
+        formatter.dateStyle = .medium
+        return formatter
+    }
+    
+    // MARK: - 숫자 포맷터
+    
+    /// 기본 숫자 포맷터
+    static var numberFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale.current
+        formatter.numberStyle = .decimal
+        return formatter
+    }
+    
+    /// 퍼센트 포맷터
+    static var percentFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale.current
+        formatter.numberStyle = .percent
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 1
+        return formatter
+    }
+    
+    /// 점수 포맷터
+    static var scoreFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale.current
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }
+    
+    // MARK: - 통화 포맷터
+    
+    /// 현재 로케일의 통화 포맷터
+    static var currencyFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale.current
+        formatter.numberStyle = .currency
+        return formatter
+    }
+    
+    /// 특정 통화 포맷터
+    /// - Parameter currencyCode: 통화 코드 (예: "USD", "JPY", "KRW")
+    /// - Returns: 설정된 NumberFormatter
+    static func currencyFormatter(for currencyCode: String) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale.current
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        return formatter
+    }
+    
+    // MARK: - 측정 포맷터
+    
+    /// 길이 측정 포맷터
+    static var lengthFormatter: MeasurementFormatter {
+        let formatter = MeasurementFormatter()
+        formatter.locale = Locale.current
+        formatter.unitStyle = .medium
+        return formatter
+    }
+    
+    /// 무게 측정 포맷터
+    static var weightFormatter: MeasurementFormatter {
+        let formatter = MeasurementFormatter()
+        formatter.locale = Locale.current
+        formatter.unitStyle = .medium
+        return formatter
+    }
+    
+    // MARK: - 헬퍼 메서드
+    
+    /// 현재 로케일에 맞는 날짜 문자열 반환
+    /// - Parameter date: 포맷할 날짜
+    /// - Returns: 로케일에 맞는 날짜 문자열
+    static func localizedDateString(from date: Date) -> String {
+        return dateFormatter.string(from: date)
+    }
+    
+    /// 현재 로케일에 맞는 시간 문자열 반환
+    /// - Parameter date: 포맷할 날짜
+    /// - Returns: 로케일에 맞는 시간 문자열
+    static func localizedTimeString(from date: Date) -> String {
+        return timeFormatter.string(from: date)
+    }
+    
+    /// 현재 로케일에 맞는 숫자 문자열 반환
+    /// - Parameter number: 포맷할 숫자
+    /// - Returns: 로케일에 맞는 숫자 문자열
+    static func localizedNumberString(from number: NSNumber) -> String {
+        return numberFormatter.string(from: number) ?? "\(number)"
+    }
+    
+    /// 점수 문자열 반환
+    /// - Parameter score: 점수
+    /// - Returns: 포맷된 점수 문자열
+    static func localizedScoreString(from score: Int) -> String {
+        return scoreFormatter.string(from: NSNumber(value: score)) ?? "\(score)"
+    }
+    
+    /// 퍼센트 문자열 반환
+    /// - Parameter value: 퍼센트 값 (0.0 ~ 1.0)
+    /// - Returns: 포맷된 퍼센트 문자열
+    static func localizedPercentString(from value: Double) -> String {
+        return percentFormatter.string(from: NSNumber(value: value)) ?? "\(Int(value * 100))%"
+    }
+    
+    /// 상대적 시간 문자열 반환 (예: "2시간 전", "1일 전")
+    /// - Parameter date: 기준 날짜
+    /// - Returns: 상대적 시간 문자열
+    static func relativeTimeString(from date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = Locale.current
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+    
+    /// 언어별 특수 포맷 처리
+    /// - Parameter text: 원본 텍스트
+    /// - Returns: 언어별 특수 포맷이 적용된 텍스트
+    static func localizedSpecialFormat(text: String) -> String {
+        let currentLanguage = Locale.current.languageCode ?? "ko"
+        
+        switch currentLanguage {
+        case "ja":
+            // 일본어: 전각 숫자 사용 (필요시)
+            return text.replacingOccurrences(of: "0", with: "０")
+                      .replacingOccurrences(of: "1", with: "１")
+                      .replacingOccurrences(of: "2", with: "２")
+                      .replacingOccurrences(of: "3", with: "３")
+                      .replacingOccurrences(of: "4", with: "４")
+                      .replacingOccurrences(of: "5", with: "５")
+                      .replacingOccurrences(of: "6", with: "６")
+                      .replacingOccurrences(of: "7", with: "７")
+                      .replacingOccurrences(of: "8", with: "８")
+                      .replacingOccurrences(of: "9", with: "９")
+        case "ko":
+            // 한국어: 특별한 포맷 없음
+            return text
+        case "en":
+            // 영어: 특별한 포맷 없음
+            return text
+        default:
+            return text
+        }
+    }
+}
+
+// MARK: - Date Extension
+extension Date {
+    
+    /// 현재 로케일에 맞는 날짜 문자열
+    var localizedDateString: String {
+        return FormatterUtils.localizedDateString(from: self)
+    }
+    
+    /// 현재 로케일에 맞는 시간 문자열
+    var localizedTimeString: String {
+        return FormatterUtils.localizedTimeString(from: self)
+    }
+    
+    /// 상대적 시간 문자열
+    var relativeTimeString: String {
+        return FormatterUtils.relativeTimeString(from: self)
+    }
+}
+
+// MARK: - Number Extension
+extension Int {
+    
+    /// 현재 로케일에 맞는 숫자 문자열
+    var localizedString: String {
+        return FormatterUtils.localizedNumberString(from: NSNumber(value: self))
+    }
+    
+    /// 점수 형태의 문자열
+    var localizedScoreString: String {
+        return FormatterUtils.localizedScoreString(from: self)
+    }
+}
+
+// MARK: - Double Extension
+extension Double {
+    
+    /// 현재 로케일에 맞는 숫자 문자열
+    var localizedString: String {
+        return FormatterUtils.localizedNumberString(from: NSNumber(value: self))
+    }
+    
+    /// 퍼센트 형태의 문자열
+    var localizedPercentString: String {
+        return FormatterUtils.localizedPercentString(from: self)
+    }
+}

--- a/WordQuizDaily/WordQuizDaily/Helpers/LocalizationHelper.swift
+++ b/WordQuizDaily/WordQuizDaily/Helpers/LocalizationHelper.swift
@@ -1,0 +1,226 @@
+//
+//  LocalizationHelper.swift
+//  WordQuizDaily
+//
+//  Created on 2025-07-18.
+//  로컬라이제이션을 위한 헬퍼 클래스
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - 로컬라이제이션 헬퍼
+struct LocalizationHelper {
+    
+    /// 현재 설정된 언어 코드 반환
+    static var currentLanguage: String {
+        return Locale.current.languageCode ?? "ko"
+    }
+    
+    /// 앱에서 지원하는 언어 목록
+    static let supportedLanguages = ["ko", "en", "ja"]
+    
+    /// 언어 이름 매핑
+    static let languageNames: [String: String] = [
+        "ko": "한국어",
+        "en": "English",
+        "ja": "日本語"
+    ]
+    
+    /// 특정 키에 대한 로컬라이즈된 문자열 반환
+    /// - Parameters:
+    ///   - key: 로컬라이제이션 키
+    ///   - arguments: 문자열 포맷 인수
+    /// - Returns: 로컬라이즈된 문자열
+    static func localizedString(for key: String, arguments: CVarArg...) -> String {
+        let format = NSLocalizedString(key, comment: "")
+        return String(format: format, arguments: arguments)
+    }
+}
+
+// MARK: - String Extension for Localization
+extension String {
+    
+    /// 로컬라이제이션된 문자열 반환
+    var localized: String {
+        return NSLocalizedString(self, comment: "")
+    }
+    
+    /// 매개변수와 함께 로컬라이제이션된 문자열 반환
+    /// - Parameter arguments: 포맷 인수
+    /// - Returns: 로컬라이즈된 문자열
+    func localized(with arguments: CVarArg...) -> String {
+        let format = NSLocalizedString(self, comment: "")
+        return String(format: format, arguments: arguments)
+    }
+}
+
+// MARK: - LocalizedStringKey Extensions
+extension LocalizedStringKey {
+    
+    /// String으로부터 LocalizedStringKey 생성
+    /// - Parameter key: 로컬라이제이션 키
+    init(_ key: String) {
+        self.init(stringLiteral: key)
+    }
+}
+
+// MARK: - SwiftUI Preview를 위한 로케일 설정
+extension View {
+    
+    /// SwiftUI 프리뷰에서 특정 언어로 표시
+    /// - Parameter language: 언어 코드 (예: "ko", "en", "ja")
+    /// - Returns: 언어가 설정된 뷰
+    func previewLocale(_ language: String) -> some View {
+        self.environment(\.locale, Locale(identifier: language))
+    }
+}
+
+// MARK: - 로컬라이제이션 키 열거형
+enum LocalizationKeys {
+    
+    // MARK: Common
+    enum Common {
+        static let ok = "common.ok"
+        static let cancel = "common.cancel"
+        static let save = "common.save"
+        static let delete = "common.delete"
+        static let edit = "common.edit"
+        static let done = "common.done"
+        static let loading = "common.loading"
+        static let error = "common.error"
+        static let retry = "common.retry"
+        static let close = "common.close"
+    }
+    
+    // MARK: Tab Bar
+    enum Tab {
+        static let home = "tab.home"
+        static let quiz = "tab.quiz"
+        static let settings = "tab.settings"
+    }
+    
+    // MARK: Home Screen
+    enum Home {
+        static let title = "home.title"
+        static let subtitle = "home.subtitle"
+        static let todayWord = "home.todayWord"
+        static let startQuiz = "home.startQuiz"
+        static let studyCount = "home.studyCount"
+        static let streakCount = "home.streakCount"
+    }
+    
+    // MARK: Quiz Screen
+    enum Quiz {
+        static let title = "quiz.title"
+        static let question = "quiz.question"
+        static let nextButton = "quiz.nextButton"
+        static let submitButton = "quiz.submitButton"
+        static let finishButton = "quiz.finishButton"
+        static let correct = "quiz.correct"
+        static let incorrect = "quiz.incorrect"
+        static let correctAnswer = "quiz.correctAnswer"
+        static let score = "quiz.score"
+        static let completion = "quiz.completion"
+        static let totalScore = "quiz.totalScore"
+        static let restartButton = "quiz.restartButton"
+        static let homeButton = "quiz.homeButton"
+        static let loadingImages = "quiz.loadingImages"
+        static let selectedWord = "quiz.selectedWord"
+        static let isCorrect = "quiz.isCorrect"
+    }
+    
+    // MARK: Settings Screen
+    enum Settings {
+        static let title = "settings.title"
+        static let notification = "settings.notification"
+        static let language = "settings.language"
+        static let theme = "settings.theme"
+        static let about = "settings.about"
+        static let version = "settings.version"
+        static let contact = "settings.contact"
+        static let privacy = "settings.privacy"
+        static let terms = "settings.terms"
+        static let notificationSection = "settings.notificationSection"
+        static let otherSection = "settings.otherSection"
+        static let termsOfService = "settings.termsOfService"
+        static let appVersion = "settings.appVersion"
+        static let customerService = "settings.customerService"
+        static let feedback = "settings.feedback"
+        static let pushNotification = "settings.pushNotification"
+    }
+    
+    // MARK: Notification Settings
+    enum Notification {
+        static let title = "notification.title"
+        static let daily = "notification.daily"
+        static let time = "notification.time"
+        static let sound = "notification.sound"
+        static let permissionTitle = "notification.permission.title"
+        static let permissionMessage = "notification.permission.message"
+        static let permissionSettings = "notification.permission.settings"
+        static let alertTitle = "notification.alert.title"
+        static let alertMessage = "notification.alert.message"
+        static let alertGoToSettings = "notification.alert.goToSettings"
+    }
+    
+    // MARK: Error Messages
+    enum Error {
+        static let network = "error.network"
+        static let unknown = "error.unknown"
+        static let dataLoad = "error.dataLoad"
+        static let permission = "error.permission"
+    }
+    
+    // MARK: Success Messages
+    enum Success {
+        static let save = "success.save"
+        static let update = "success.update"
+        static let delete = "success.delete"
+    }
+    
+    // MARK: Word Related
+    enum Word {
+        static let meaning = "word.meaning"
+        static let pronunciation = "word.pronunciation"
+        static let example = "word.example"
+        static let difficulty = "word.difficulty"
+        static let category = "word.category"
+        static let bookmark = "word.bookmark"
+        static let learned = "word.learned"
+        static let learning = "word.learning"
+        static let notStarted = "word.notStarted"
+    }
+    
+    // MARK: Terms of Service
+    enum TermsOfService {
+        static let title = "terms.title"
+        static let content = "terms.content"
+    }
+    
+    // MARK: App Version
+    enum AppVersion {
+        static let title = "appVersion.title"
+        static let currentVersion = "appVersion.current"
+        static let updateHistory = "appVersion.updateHistory"
+        static let version100 = "appVersion.version100"
+    }
+    
+    // MARK: Customer Service
+    enum CustomerService {
+        static let title = "customerService.title"
+        static let contactInfo = "customerService.contactInfo"
+        static let faq = "customerService.faq"
+        static let faqPassword = "customerService.faqPassword"
+        static let faqPasswordAnswer = "customerService.faqPasswordAnswer"
+        static let faqNotWorking = "customerService.faqNotWorking"
+        static let faqNotWorkingAnswer = "customerService.faqNotWorkingAnswer"
+    }
+    
+    // MARK: Feedback
+    enum Feedback {
+        static let title = "feedback.title"
+        static let content = "feedback.content"
+        static let contactInfo = "feedback.contactInfo"
+    }
+}

--- a/WordQuizDaily/WordQuizDaily/Helpers/LocalizationHelper.swift
+++ b/WordQuizDaily/WordQuizDaily/Helpers/LocalizationHelper.swift
@@ -14,7 +14,11 @@ struct LocalizationHelper {
     
     /// 현재 설정된 언어 코드 반환
     static var currentLanguage: String {
-        return Locale.current.languageCode ?? "ko"
+        if #available(iOS 16, *) {
+            return Locale.current.language.languageCode?.identifier ?? "ko"
+        } else {
+            return Locale.current.languageCode ?? "ko"
+        }
     }
     
     /// 앱에서 지원하는 언어 목록

--- a/WordQuizDaily/WordQuizDaily/Resources/Localizations/en.lproj/InfoPlist.strings
+++ b/WordQuizDaily/WordQuizDaily/Resources/Localizations/en.lproj/InfoPlist.strings
@@ -1,0 +1,20 @@
+/* 
+  InfoPlist.strings
+  WordQuizDaily
+
+  English
+  Created on 2025-07-18.
+*/
+
+// App Name
+"CFBundleDisplayName" = "Word Quiz Daily";
+
+// Usage Descriptions
+"NSCameraUsageDescription" = "Camera access is needed to take or select word-related images.";
+"NSPhotoLibraryUsageDescription" = "Photo library access is needed to select word-related images.";
+"NSMicrophoneUsageDescription" = "Microphone access is needed for word pronunciation recording features.";
+"NSUserNotificationsUsageDescription" = "Notification permission is needed to receive daily word quiz reminders.";
+
+// Location Permission (if needed)
+"NSLocationWhenInUseUsageDescription" = "Location information is needed to provide region-specific word recommendations.";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "Location information is needed to provide region-specific word recommendations.";

--- a/WordQuizDaily/WordQuizDaily/Resources/Localizations/en.lproj/Localizable.strings
+++ b/WordQuizDaily/WordQuizDaily/Resources/Localizations/en.lproj/Localizable.strings
@@ -1,0 +1,187 @@
+//Localizable.strings
+//WordQuizDaily
+//
+//English - 영어
+//Created on 2025-07-18.
+
+
+// MARK: - Common
+"common.ok" = "OK";
+"common.cancel" = "Cancel";
+"common.save" = "Save";
+"common.delete" = "Delete";
+"common.edit" = "Edit";
+"common.done" = "Done";
+"common.loading" = "Loading...";
+"common.error" = "Error";
+"common.retry" = "Retry";
+"common.close" = "Close";
+
+// MARK: - Tab Bar
+"tab.home" = "Home";
+"tab.quiz" = "Quiz";
+"tab.settings" = "Settings";
+
+// MARK: - Home Screen
+"home.title" = "Word Quiz Daily";
+"home.subtitle" = "Meet new words every day";
+"home.todayWord" = "Today's Word";
+"home.startQuiz" = "Start Quiz";
+"home.studyCount" = "Words Studied: %d";
+"home.streakCount" = "Study Streak: %d days";
+
+// MARK: - Quiz Screen
+"quiz.title" = "Word Quiz";
+"quiz.question" = "Question %d / %d";
+"quiz.nextButton" = "Next";
+"quiz.submitButton" = "Submit";
+"quiz.finishButton" = "Finish";
+"quiz.correct" = "Correct!";
+"quiz.incorrect" = "Incorrect.";
+"quiz.correctAnswer" = "Answer: %@";
+"quiz.score" = "Score: %d points";
+"quiz.completion" = "Quiz Complete!";
+"quiz.totalScore" = "Total Score: %d / %d";
+"quiz.restartButton" = "Restart";
+"quiz.homeButton" = "Home";
+"quiz.loadingImages" = "Loading images...";
+"quiz.selectedWord" = "Selected word";
+"quiz.isCorrect" = "Correct";
+
+// MARK: - Settings Screen
+"settings.title" = "Settings";
+"settings.notification" = "Notifications";
+"settings.language" = "Language";
+"settings.theme" = "Theme";
+"settings.about" = "About";
+"settings.version" = "Version";
+"settings.contact" = "Contact";
+"settings.privacy" = "Privacy Policy";
+"settings.terms" = "Terms of Service";
+"settings.notificationSection" = "Notification Settings";
+"settings.otherSection" = "Other Settings";
+"settings.termsOfService" = "Terms of Service";
+"settings.appVersion" = "App Version";
+"settings.customerService" = "Customer Support";
+"settings.feedback" = "Feedback";
+"settings.pushNotification" = "Push Notifications";
+
+// MARK: - Notification Settings
+"notification.title" = "Notification Settings";
+"notification.daily" = "Daily Notifications";
+"notification.time" = "Notification Time";
+"notification.sound" = "Notification Sound";
+"notification.permission.title" = "Notification Permission Required";
+"notification.permission.message" = "Notification permission is required to receive word quiz alerts.";
+"notification.permission.settings" = "Go to Settings";
+"notification.alert.title" = "Notification Alert";
+"notification.alert.message" = "Notifications are disabled. Please enable notifications in Settings.";
+"notification.alert.goToSettings" = "Go"; 
+
+// MARK: - Common
+"common.ok" = "OK";
+"common.cancel" = "Cancel";
+"common.save" = "Save";
+"common.delete" = "Delete";
+"common.edit" = "Edit";
+"common.done" = "Done";
+"common.loading" = "Loading...";
+"common.error" = "Error";
+"common.retry" = "Retry";
+"common.close" = "Close";
+
+// MARK: - Tab Bar
+"tab.home" = "Home";
+"tab.quiz" = "Quiz";
+"tab.settings" = "Settings";
+
+// MARK: - Home Screen
+"home.title" = "Word Quiz Daily";
+"home.subtitle" = "Meet new words every day";
+"home.todayWord" = "Today's Word";
+"home.startQuiz" = "Start Quiz";
+"home.studyCount" = "Words Studied: %d";
+"home.streakCount" = "Study Streak: %d days";
+
+// MARK: - Quiz Screen
+"quiz.title" = "Word Quiz";
+"quiz.question" = "Question %d / %d";
+"quiz.nextButton" = "Next";
+"quiz.submitButton" = "Submit";
+"quiz.finishButton" = "Finish";
+"quiz.correct" = "Correct!";
+"quiz.incorrect" = "Incorrect.";
+"quiz.correctAnswer" = "Answer: %@";
+"quiz.score" = "Score: %d points";
+"quiz.completion" = "Quiz Complete!";
+"quiz.totalScore" = "Total Score: %d / %d";
+"quiz.restartButton" = "Restart";
+"quiz.homeButton" = "Home";
+"quiz.loadingImages" = "Loading images...";
+"quiz.selectedWord" = "Selected word";
+"quiz.isCorrect" = "Correct";
+
+// MARK: - Settings Screen
+"settings.title" = "Settings";
+"settings.notification" = "Notifications";
+"settings.language" = "Language";
+"settings.theme" = "Theme";
+"settings.about" = "About";
+"settings.version" = "Version";
+"settings.contact" = "Contact";
+"settings.privacy" = "Privacy Policy";
+"settings.terms" = "Terms of Service";
+
+// MARK: - Notification Settings
+"notification.title" = "Notification Settings";
+"notification.daily" = "Daily Notifications";
+"notification.time" = "Notification Time";
+"notification.sound" = "Notification Sound";
+"notification.permission.title" = "Notification Permission Required";
+"notification.permission.message" = "Please allow notifications to receive word quiz reminders.";
+"notification.permission.settings" = "Go to Settings";
+
+// MARK: - Error Messages
+"error.network" = "Please check your network connection.";
+"error.unknown" = "An unknown error occurred.";
+"error.dataLoad" = "An error occurred while loading data.";
+"error.permission" = "Permission required.";
+
+// MARK: - Success Messages
+"success.save" = "Saved successfully.";
+"success.update" = "Updated successfully.";
+"success.delete" = "Deleted successfully.";
+
+// MARK: - Word Related
+"word.meaning" = "Meaning";
+"word.pronunciation" = "Pronunciation";
+"word.example" = "Example";
+"word.difficulty" = "Difficulty";
+"word.category" = "Category";
+"word.bookmark" = "Bookmark";
+"word.learned" = "Learned";
+"word.learning" = "Learning";
+"word.notStarted" = "Not Started";
+
+// MARK: - Terms of Service
+"terms.title" = "Terms of Service";
+"terms.content" = "Last Modified: July 01, 2024\n\n1. Overview\nThese Terms of Service (\"Terms\") set forth the legal conditions governing the use of WordQuizDaily (\"App\"). Provided by individual developer Jongwon Jeong, by downloading or using the app, users are deemed to agree to these terms.\n\n2. Service Usage\n2.1 Permitted Use: Users must use the app for legal purposes only. Illegal activities or actions that violate our policies are strictly prohibited.\n2.2 Restricted Use: Users may not use the app in ways such as hacking, spamming, or distributing viruses. We reserve the right to restrict user access to the app.\n\n3. API Usage\n3.1 External APIs: This app uses Naver Image Search API and Urimalsaem Word Search API. Users must comply with the terms of service of these API providers.\n\n4. Content\n4.1 User Content: Users retain rights to all content they upload or post to the app. However, users grant us a non-exclusive, perpetual, irrevocable right to use such content within the app.\n4.2 Prohibited Content: Users may not post illegal content including defamation, obscenity, violence, hate speech, etc.\n\n5. Privacy Protection\n5.1 Personal Information Collection: This app does not require login. User personal information is not collected, therefore there is no separate privacy policy.\n\n6. Third-Party Services\nThe app may include third-party services or content. We are not responsible for third-party services, and users must comply with the terms of such third-party services.\n\n7. Disclaimer\nThe app is provided \"as is\" and we do not warrant the accuracy, reliability, or completeness of the app. Users must assume all risks associated with using the app.\n\n8. Limitation of Liability\nTo the maximum extent permitted by law, we are not liable for any direct or indirect damages related to app usage.\n\n9. Changes to Terms\nWe reserve the right to modify these terms at any time. Changes will be posted within the app, and users are deemed to agree to the modified terms.\n\n10. Termination\nWe may terminate user access to the app at any time without prior notice if users violate these terms.\n\n11. Governing Law and Dispute Resolution\nThese terms are governed by the laws of the Republic of Korea, and all disputes related to the terms are subject to the exclusive jurisdiction of Korean courts.\n\n12. Contact Information\nFor questions about the terms, please contact:\n\nJongwon Jeong\nEmail: jjwon2149@gmail.com";
+
+// MARK: - App Version
+"appVersion.title" = "App Version";
+"appVersion.current" = "Current Version: 1.0.0";
+"appVersion.updateHistory" = "Update History:\n- Version 1.0.0: Initial Release";
+
+// MARK: - Customer Service
+"customerService.title" = "Customer Support";
+"customerService.contactInfo" = "Customer Support Contact:\n- Email: jjwon2149@gmail.com";
+"customerService.faq" = "Frequently Asked Questions";
+"customerService.faqPassword" = "Q: I forgot my password.";
+"customerService.faqPasswordAnswer" = "A: This app does not require login.";
+"customerService.faqNotWorking" = "Q: The app is not working properly.";
+"customerService.faqNotWorkingAnswer" = "A: Try reinstalling the app or updating to the latest version. If the problem persists, please contact customer support.";
+
+// MARK: - Feedback
+"feedback.title" = "Feedback";
+"feedback.content" = "If you have any inconveniences or suggestions while using the app, please send us feedback anytime. Your opinions are very helpful to us.";
+"feedback.contactInfo" = "Send Feedback:\n- Email: jjwon2149@gmail.com\n- Sharp criticism will be reflected immediately ^_^";

--- a/WordQuizDaily/WordQuizDaily/Resources/Localizations/ja.lproj/InfoPlist.strings
+++ b/WordQuizDaily/WordQuizDaily/Resources/Localizations/ja.lproj/InfoPlist.strings
@@ -1,0 +1,20 @@
+/* 
+  InfoPlist.strings
+  WordQuizDaily
+
+  Japanese (日本語)
+  Created on 2025-07-18.
+*/
+
+// アプリ名
+"CFBundleDisplayName" = "単語クイズデイリー";
+
+// 使用目的の説明
+"NSCameraUsageDescription" = "単語に関連する画像を撮影または選択するため、カメラへのアクセスが必要です。";
+"NSPhotoLibraryUsageDescription" = "単語に関連する画像を選択するため、フォトライブラリへのアクセスが必要です。";
+"NSMicrophoneUsageDescription" = "単語の発音録音機能を使用するため、マイクへのアクセスが必要です。";
+"NSUserNotificationsUsageDescription" = "毎日の単語クイズ通知を受け取るため、通知権限が必要です。";
+
+// 位置情報権限（必要な場合）
+"NSLocationWhenInUseUsageDescription" = "地域別の単語推薦機能を提供するため、位置情報が必要です。";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "地域別の単語推薦機能を提供するため、位置情報が必要です。";

--- a/WordQuizDaily/WordQuizDaily/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/WordQuizDaily/WordQuizDaily/Resources/Localizations/ja.lproj/Localizable.strings
@@ -1,0 +1,196 @@
+//Localizable.strings
+//WordQuizDaily
+//
+//Japanese (日本語) - 일본어
+//Created on 2025-07-18.
+//
+//Translation Notes:
+//- Use polite form (です/ます調) for user-facing text
+//- Keep button labels concise using katakana when appropriate
+//- Consider full-width/half-width character rules
+
+
+// MARK: - 共通 (Common)
+"common.ok" = "OK";
+"common.cancel" = "キャンセル";
+"common.save" = "保存";
+"common.delete" = "削除";
+"common.edit" = "編集";
+"common.done" = "完了";
+"common.loading" = "読み込み中...";
+"common.error" = "エラー";
+"common.retry" = "再試行";
+"common.close" = "閉じる";
+
+// MARK: - タブバー (Tab Bar)
+"tab.home" = "ホーム";
+"tab.quiz" = "クイズ";
+"tab.settings" = "設定";
+
+// MARK: - ホーム画面 (Home Screen)
+"home.title" = "単語クイズデイリー";
+"home.subtitle" = "毎日新しい単語と出会おう";
+"home.todayWord" = "今日の単語";
+"home.startQuiz" = "クイズを始める";
+"home.studyCount" = "学習した単語：%d個";
+"home.streakCount" = "連続学習：%d日";
+
+// MARK: - クイズ画面 (Quiz Screen)
+"quiz.title" = "単語クイズ";
+"quiz.question" = "問題 %d / %d";
+"quiz.nextButton" = "次へ";
+"quiz.submitButton" = "回答";
+"quiz.finishButton" = "終了";
+"quiz.correct" = "正解です！";
+"quiz.incorrect" = "不正解です。";
+"quiz.correctAnswer" = "正解：%@";
+"quiz.score" = "スコア：%d点";
+"quiz.completion" = "クイズ完了！";
+"quiz.totalScore" = "合計スコア：%d / %d";
+"quiz.restartButton" = "再開始";
+"quiz.homeButton" = "ホーム";
+"quiz.loadingImages" = "画像読み込み中...";
+"quiz.selectedWord" = "選択した単語";
+"quiz.isCorrect" = "正解";
+
+// MARK: - 設定画面 (Settings Screen)
+"settings.title" = "設定";
+"settings.notification" = "通知設定";
+"settings.language" = "言語";
+"settings.theme" = "テーマ";
+"settings.about" = "アプリについて";
+"settings.version" = "バージョン";
+"settings.contact" = "お問い合わせ";
+"settings.privacy" = "プライバシーポリシー";
+"settings.terms" = "利用規約";
+"settings.notificationSection" = "通知設定";
+"settings.otherSection" = "その他の設定";
+"settings.termsOfService" = "サービス利用規約";
+"settings.appVersion" = "アプリバージョン";
+"settings.customerService" = "カスタマーサポート";
+"settings.feedback" = "フィードバック";
+"settings.pushNotification" = "プッシュ通知";
+
+// MARK: - 通知設定 (Notification Settings)
+"notification.title" = "通知設定";
+"notification.daily" = "毎日の通知";
+"notification.time" = "通知時間";
+"notification.sound" = "通知音";
+"notification.permission.title" = "通知許可が必要です";
+"notification.permission.message" = "単語クイズの通知を受け取るには通知許可が必要です。";
+"notification.permission.settings" = "設定に移動";
+"notification.alert.title" = "通知アラート";
+"notification.alert.message" = "通知設定がオフになっています。設定で通知をオンにしてください。";
+"notification.alert.goToSettings" = "移動";
+
+// MARK: - 共通 (Common)
+"common.ok" = "OK";
+"common.cancel" = "キャンセル";
+"common.save" = "保存";
+"common.delete" = "削除";
+"common.edit" = "編集";
+"common.done" = "完了";
+"common.loading" = "読み込み中...";
+"common.error" = "エラー";
+"common.retry" = "再試行";
+"common.close" = "閉じる";
+
+// MARK: - タブバー (Tab Bar)
+"tab.home" = "ホーム";
+"tab.quiz" = "クイズ";
+"tab.settings" = "設定";
+
+// MARK: - ホーム画面 (Home Screen)
+"home.title" = "単語クイズデイリー";
+"home.subtitle" = "毎日新しい単語と出会おう";
+"home.todayWord" = "今日の単語";
+"home.startQuiz" = "クイズを始める";
+"home.studyCount" = "学習した単語：%d個";
+"home.streakCount" = "連続学習：%d日";
+
+// MARK: - クイズ画面 (Quiz Screen)
+"quiz.title" = "単語クイズ";
+"quiz.question" = "問題 %d / %d";
+"quiz.nextButton" = "次へ";
+"quiz.submitButton" = "回答";
+"quiz.finishButton" = "終了";
+"quiz.correct" = "正解です！";
+"quiz.incorrect" = "不正解です。";
+"quiz.correctAnswer" = "正解：%@";
+"quiz.score" = "スコア：%d点";
+"quiz.completion" = "クイズ完了！";
+"quiz.totalScore" = "合計スコア：%d / %d";
+"quiz.restartButton" = "再開始";
+"quiz.homeButton" = "ホーム";
+"quiz.loadingImages" = "画像読み込み中...";
+"quiz.selectedWord" = "選択した単語";
+"quiz.isCorrect" = "正解";
+
+// MARK: - 設定画面 (Settings Screen)
+"settings.title" = "設定";
+"settings.notification" = "通知設定";
+"settings.language" = "言語";
+"settings.theme" = "テーマ";
+"settings.about" = "アプリについて";
+"settings.version" = "バージョン";
+"settings.contact" = "お問い合わせ";
+"settings.privacy" = "プライバシーポリシー";
+"settings.terms" = "利用規約";
+
+// MARK: - 通知設定 (Notification Settings)
+"notification.title" = "通知設定";
+"notification.daily" = "毎日の通知";
+"notification.time" = "通知時間";
+"notification.sound" = "通知音";
+"notification.permission.title" = "通知許可が必要です";
+"notification.permission.message" = "単語クイズの通知を受け取るには、通知許可が必要です。";
+"notification.permission.settings" = "設定へ移動";
+
+// MARK: - エラーメッセージ (Error Messages)
+"error.network" = "ネットワーク接続を確認してください。";
+"error.unknown" = "不明なエラーが発生しました。";
+"error.dataLoad" = "データの読み込み中にエラーが発生しました。";
+"error.permission" = "権限が必要です。";
+
+// MARK: - 成功メッセージ (Success Messages)
+"success.save" = "保存されました。";
+"success.update" = "更新されました。";
+"success.delete" = "削除されました。";
+
+// MARK: - 単語関連 (Word Related)
+"word.meaning" = "意味";
+"word.pronunciation" = "発音";
+"word.example" = "例文";
+"word.difficulty" = "難易度";
+"word.category" = "カテゴリ";
+"word.bookmark" = "ブックマーク";
+"word.learned" = "学習済み";
+"word.learning" = "学習中";
+"word.notStarted" = "未学習";
+
+// MARK: - サービス利用規約 (Terms of Service)
+"terms.title" = "サービス利用規約";
+"terms.content" = "最終更新日：2024年07月01日\n\n1. 概要\nこのサービス利用規約（「規約」）は、WordQuizDaily（「アプリ」）の利用に関する法的条件を定めるものです。個人開発者である정종원により提供され、ユーザーはアプリをダウンロードまたは使用することにより、本規約に同意したものとみなされます。\n\n2. サービス利用\n2.1 許可された使用：ユーザーは法的目的でのみアプリを使用する必要があります。違法な活動や当社のポリシーに違反する行為は厳しく禁止されています。\n2.2 制限された使用：ユーザーはハッキング、スパム送信、ウイルス配布などの方法でアプリを使用することはできません。当社はユーザーのアプリアクセスを制限する権利を有します。\n\n3. API使用\n3.1 外部API：本アプリはNaver画像検索APIとUrimalsaem単語検索APIを使用します。ユーザーは該当API提供者の利用規約を遵守する必要があります。\n\n4. コンテンツ\n4.1 ユーザーコンテンツ：ユーザーはアプリにアップロードまたは投稿したすべてのコンテンツに対する権利を保持します。ただし、ユーザーは当社に該当コンテンツをアプリ内で使用できる非独占的、永続的、取消不可能な権利を付与します。\n4.2 禁止されたコンテンツ：ユーザーは名誉毀損、わいせつ物、暴力、憎悪発言などを含む違法なコンテンツを投稿することはできません。\n\n5. プライバシー保護\n5.1 個人情報収集：本アプリはログインが不要です。ユーザーの個人情報は収集されないため、別途のプライバシーポリシーはありません。\n\n6. 第三者サービス\nアプリは第三者サービスやコンテンツを含む場合があります。当社は第三者サービスについて責任を負わず、ユーザーは該当第三者サービスの規約を遵守する必要があります。\n\n7. 免責事項\nアプリは「現状のまま」提供され、当社はアプリの正確性、信頼性、完全性について保証しません。ユーザーはアプリ使用に伴うすべてのリスクを負担する必要があります。\n\n8. 責任の制限\n法律が許可する最大限度内で、当社はアプリ使用に関連する直接的または間接的損害について責任を負いません。\n\n9. 規約の変更\n当社はいつでもこの規約を修正する権利を有します。変更事項はアプリ内に掲載され、ユーザーは変更された規約に同意したものとみなされます。\n\n10. 終了\n当社はユーザーがこの規約に違反した場合、いつでも事前通知なしにユーザーのアプリアクセスを終了することができます。\n\n11. 準拠法および紛争解決\nこの規約は大韓民国の法律に従って解釈され、規約に関連するすべての紛争は大韓民国の法院に専属管轄権があります。\n\n12. 連絡先情報\n規約に関する質問は下記連絡先にお問い合わせください：\n\n정종원\nメール：jjwon2149@gmail.com";
+
+// MARK: - アプリバージョン (App Version)
+"appVersion.title" = "アプリバージョン";
+"appVersion.current" = "現在のバージョン：1.0.0";
+"appVersion.updateHistory" = "更新履歴：\n- バージョン1.0.0：初回リリース";
+
+// MARK: - カスタマーサポート (Customer Service)
+"customerService.title" = "カスタマーサポート";
+"customerService.contactInfo" = "カスタマーサポートお問い合わせ：\n- メール：jjwon2149@gmail.com";
+"customerService.faq" = "よくある質問";
+"customerService.faqPassword" = "Q：パスワードを忘れました。";
+"customerService.faqPasswordAnswer" = "A：このアプリはログインが不要です。";
+"customerService.faqNotWorking" = "Q：アプリが正常に動作しません。";
+"customerService.faqNotWorkingAnswer" = "A：アプリを再インストールするか、最新バージョンにアップデートしてみてください。それでも問題が解決しない場合は、カスタマーサポートにお問い合わせください。";
+
+// MARK: - フィードバック (Feedback)
+"feedback.title" = "フィードバック";
+"feedback.content" = "アプリ使用中にご不便な点や改善事項がございましたら、いつでもフィードバックをお送りください。皆様のご意見は私たちにとって大きな助けとなります。";
+"feedback.contactInfo" = "フィードバック送信：\n- メール：jjwon2149@gmail.com\n- 鋭いご指摘をいただければすぐに反映いたします ^_^";
+"word.bookmark" = "ブックマーク";
+"word.learned" = "学習完了";
+"word.learning" = "学習中";
+"word.notStarted" = "未学習";

--- a/WordQuizDaily/WordQuizDaily/Resources/Localizations/ko.lproj/InfoPlist.strings
+++ b/WordQuizDaily/WordQuizDaily/Resources/Localizations/ko.lproj/InfoPlist.strings
@@ -1,0 +1,20 @@
+/* 
+  InfoPlist.strings
+  WordQuizDaily
+
+  Korean (한국어) - 기본 언어
+  Created on 2025-07-18.
+*/
+
+// 앱 이름
+"CFBundleDisplayName" = "단어퀴즈데일리";
+
+// 사용 목적 설명
+"NSCameraUsageDescription" = "단어 관련 이미지를 촬영하거나 선택하기 위해 카메라 권한이 필요합니다.";
+"NSPhotoLibraryUsageDescription" = "단어 관련 이미지를 선택하기 위해 사진 라이브러리 권한이 필요합니다.";
+"NSMicrophoneUsageDescription" = "단어 발음 녹음 기능을 사용하기 위해 마이크 권한이 필요합니다.";
+"NSUserNotificationsUsageDescription" = "매일 단어 퀴즈 알림을 받기 위해 알림 권한이 필요합니다.";
+
+// 위치 권한 (필요한 경우)
+"NSLocationWhenInUseUsageDescription" = "지역별 단어 추천 기능을 제공하기 위해 위치 정보가 필요합니다.";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "지역별 단어 추천 기능을 제공하기 위해 위치 정보가 필요합니다.";

--- a/WordQuizDaily/WordQuizDaily/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/WordQuizDaily/WordQuizDaily/Resources/Localizations/ko.lproj/Localizable.strings
@@ -1,0 +1,125 @@
+/* 
+  Localizable.strings
+  WordQuizDaily
+
+  Korean (한국어) - 기본 언어
+  Created on 2025-07-18.
+*/
+
+// MARK: - 공통 (Common)
+"common.ok" = "확인";
+"common.cancel" = "취소";
+"common.save" = "저장";
+"common.delete" = "삭제";
+"common.edit" = "편집";
+"common.done" = "완료";
+"common.loading" = "로딩 중...";
+"common.error" = "오류";
+"common.retry" = "다시 시도";
+"common.close" = "닫기";
+
+// MARK: - 탭 바 (Tab Bar)
+"tab.home" = "홈";
+"tab.quiz" = "퀴즈";
+"tab.settings" = "설정";
+
+// MARK: - 홈 화면 (Home Screen)
+"home.title" = "단어 퀴즈 데일리";
+"home.subtitle" = "매일 새로운 단어와 만나보세요";
+"home.todayWord" = "오늘의 단어";
+"home.startQuiz" = "퀴즈 시작하기";
+"home.studyCount" = "학습한 단어: %d개";
+"home.streakCount" = "연속 학습: %d일";
+
+// MARK: - 퀴즈 화면 (Quiz Screen)
+"quiz.title" = "단어 퀴즈";
+"quiz.question" = "문제 %d / %d";
+"quiz.nextButton" = "다음";
+"quiz.submitButton" = "제출";
+"quiz.finishButton" = "완료";
+"quiz.correct" = "정답입니다!";
+"quiz.incorrect" = "틀렸습니다.";
+"quiz.correctAnswer" = "정답: %@";
+"quiz.score" = "점수: %d점";
+"quiz.completion" = "퀴즈 완료!";
+"quiz.totalScore" = "총 점수: %d / %d";
+"quiz.restartButton" = "다시 시작";
+"quiz.homeButton" = "홈으로";
+"quiz.loadingImages" = "이미지 로딩 중...";
+"quiz.selectedWord" = "선택된 단어";
+"quiz.isCorrect" = "정답";
+
+// MARK: - 설정 화면 (Settings Screen)
+"settings.title" = "설정";
+"settings.notification" = "알림 설정";
+"settings.language" = "언어";
+"settings.theme" = "테마";
+"settings.about" = "앱 정보";
+"settings.version" = "버전";
+"settings.contact" = "문의하기";
+"settings.privacy" = "개인정보처리방침";
+"settings.terms" = "이용약관";
+"settings.notificationSection" = "알림 설정";
+"settings.otherSection" = "기타 설정";
+"settings.termsOfService" = "서비스 약관";
+"settings.appVersion" = "앱 버전";
+"settings.customerService" = "고객 지원";
+"settings.feedback" = "피드백";
+"settings.pushNotification" = "푸시 알림";
+
+// MARK: - 알림 설정 (Notification Settings)
+"notification.title" = "알림 설정";
+"notification.daily" = "매일 알림";
+"notification.time" = "알림 시간";
+"notification.sound" = "알림음";
+"notification.permission.title" = "알림 권한 필요";
+"notification.permission.message" = "단어 퀴즈 알림을 받으려면 알림 권한이 필요합니다.";
+"notification.permission.settings" = "설정으로 이동";
+"notification.alert.title" = "알림 설정 필요";
+"notification.alert.message" = "알림 설정이 꺼져있습니다. 설정에서 알림을 켜주세요.";
+"notification.alert.goToSettings" = "이동";
+
+// MARK: - 오류 메시지 (Error Messages)
+"error.network" = "네트워크 연결을 확인해주세요.";
+"error.unknown" = "알 수 없는 오류가 발생했습니다.";
+"error.dataLoad" = "데이터를 불러오는 중 오류가 발생했습니다.";
+"error.permission" = "권한이 필요합니다.";
+
+// MARK: - 성공 메시지 (Success Messages)
+"success.save" = "저장되었습니다.";
+"success.update" = "업데이트되었습니다.";
+"success.delete" = "삭제되었습니다.";
+
+// MARK: - 단어 관련 (Word Related)
+"word.meaning" = "뜻";
+"word.pronunciation" = "발음";
+"word.example" = "예문";
+"word.difficulty" = "난이도";
+"word.category" = "카테고리";
+"word.bookmark" = "즐겨찾기";
+"word.learned" = "학습 완료";
+"word.learning" = "학습 중";
+"word.notStarted" = "학습 전";
+
+// MARK: - 서비스 약관 (Terms of Service)
+"terms.title" = "서비스 약관";
+"terms.content" = "최종 수정일: 2024년 07월 01일\n\n1. 개요\n이 서비스 약관(\"약관\")은 WordQuizDaily(\"앱\")의 이용에 관한 법적 조건을 명시합니다. 개인 개발자인 정종원에 의해 제공되며, 사용자는 앱을 다운로드하거나 사용함으로써 이 약관에 동의하는 것으로 간주됩니다.\n\n2. 서비스 이용\n2.1 허용된 사용: 사용자는 앱을 법적 목적으로만 사용해야 합니다. 불법적인 활동이나 당사의 정책을 위반하는 행위는 엄격히 금지됩니다.\n2.2 제한된 사용: 사용자는 앱을 해킹, 스팸 발송, 바이러스 유포 등의 방식으로 사용할 수 없습니다. 당사는 사용자의 앱 접근을 제한할 권리를 가집니다.\n\n3. API 사용\n3.1 외부 API: 본 앱은 네이버 이미지 검색 API와 우리말샘 단어 검색 API를 사용합니다. 사용자는 해당 API 제공자의 이용 약관을 준수해야 합니다.\n\n4. 콘텐츠\n4.1 사용자 콘텐츠: 사용자는 앱에 업로드하거나 게시한 모든 콘텐츠에 대한 권리를 보유합니다. 그러나 사용자는 당사에 해당 콘텐츠를 앱 내에서 사용할 수 있는 비독점적, 영구적, 취소 불가능한 권리를 부여합니다.\n4.2 금지된 콘텐츠: 사용자는 명예 훼손, 음란물, 폭력, 증오 발언 등을 포함한 불법적인 콘텐츠를 게시할 수 없습니다.\n\n5. 개인정보 보호\n5.1 개인정보 수집: 본 앱은 로그인이 필요하지 않습니다. 사용자의 개인정보는 수집되지 않으며, 따라서 별도의 개인정보 처리방침은 없습니다.\n\n6. 제3자 서비스\n앱은 제3자 서비스나 콘텐츠를 포함할 수 있습니다. 당사는 제3자 서비스에 대해 책임지지 않으며, 사용자는 해당 제3자 서비스의 약관을 준수해야 합니다.\n\n7. 면책 조항\n앱은 \"있는 그대로\" 제공되며, 당사는 앱의 정확성, 신뢰성, 완전성에 대해 보증하지 않습니다. 사용자는 앱 사용에 따른 모든 위험을 감수해야 합니다.\n\n8. 책임 제한\n법이 허용하는 최대 한도 내에서, 당사는 앱 사용과 관련된 직간접적 손해에 대해 책임지지 않습니다.\n\n9. 약관의 변경\n당사는 언제든지 이 약관을 수정할 권리를 가집니다. 변경 사항은 앱 내에 게시되며, 사용자는 변경된 약관에 동의하는 것으로 간주됩니다.\n\n10. 종료\n당사는 사용자가 이 약관을 위반하는 경우 언제든지 사전 통보 없이 사용자의 앱 접근을 종료할 수 있습니다.\n\n11. 준거법 및 분쟁 해결\n이 약관은 대한민국 법에 따라 해석되며, 약관과 관련된 모든 분쟁은 대한민국의 법원에 전속 관할권이 있습니다.\n\n12. 연락처 정보\n약관에 관한 질문은 아래 연락처로 문의해 주십시오:\n\n정종원\n이메일: jjwon2149@gmail.com";
+
+// MARK: - 앱 버전 (App Version)
+"appVersion.title" = "앱 버전";
+"appVersion.current" = "현재 버전: 1.0.0";
+"appVersion.updateHistory" = "업데이트 내역:\n- 버전 1.0.0: 최초 릴리즈";
+
+// MARK: - 고객 지원 (Customer Service)
+"customerService.title" = "고객 지원";
+"customerService.contactInfo" = "고객 지원 문의:\n- 이메일: jjwon2149@gmail.com";
+"customerService.faq" = "자주 묻는 질문";
+"customerService.faqPassword" = "Q: 비밀번호를 잊어버렸어요.";
+"customerService.faqPasswordAnswer" = "A: 이 앱은 로그인이 없습니다.";
+"customerService.faqNotWorking" = "Q: 앱이 제대로 작동하지 않아요.";
+"customerService.faqNotWorkingAnswer" = "A: 앱을 재설치하거나 최신 버전으로 업데이트해보세요. 그래도 문제가 해결되지 않으면 고객 지원에 문의하세요.";
+
+// MARK: - 피드백 (Feedback)
+"feedback.title" = "피드백";
+"feedback.content" = "앱 사용 중 불편한 점이나 개선사항이 있다면 언제든지 피드백을 보내주세요. 여러분의 의견은 저희에게 큰 도움이 됩니다.";
+"feedback.contactInfo" = "피드백 보내기:\n- 이메일: jjwon2149@gmail.com\n- 날카로운 지적 해주시면 바로 반영 하겠습니다 ^_^";

--- a/WordQuizDaily/WordQuizDaily/Resources/Localizations/pseudo.lproj/Localizable.strings
+++ b/WordQuizDaily/WordQuizDaily/Resources/Localizations/pseudo.lproj/Localizable.strings
@@ -1,0 +1,92 @@
+/* 
+  Localizable.strings
+  WordQuizDaily
+
+  Pseudo-Localization for Testing
+  Created on 2025-07-18.
+  
+  이 파일은 UI 레이아웃 테스트를 위한 의사 로컬라이제이션입니다.
+  문자열 길이 확장 및 특수 문자 처리를 테스트합니다.
+*/
+
+// MARK: - 공통 (Common) - Extended for testing
+"common.ok" = "[!!! ÖK !!!]";
+"common.cancel" = "[!!! Çàñçél !!!]";
+"common.save" = "[!!! Śàvé !!!]";
+"common.delete" = "[!!! Délétè !!!]";
+"common.edit" = "[!!! Édìt !!!]";
+"common.done" = "[!!! Dónè !!!]";
+"common.loading" = "[!!! Lóàdìñg... !!!]";
+"common.error" = "[!!! Érrór !!!]";
+"common.retry" = "[!!! Rétrÿ !!!]";
+"common.close" = "[!!! Clósé !!!]";
+
+// MARK: - 탭 바 (Tab Bar) - Extended strings
+"tab.home" = "[!!! Hómé Täb !!!]";
+"tab.quiz" = "[!!! Qûìz Täb !!!]";
+"tab.settings" = "[!!! Séttìñgs Täb !!!]";
+
+// MARK: - 홈 화면 (Home Screen) - Long strings for layout testing
+"home.title" = "[!!! Wórd Qûìz Dàìlÿ Äpplìcàtìón !!!]";
+"home.subtitle" = "[!!! Méét ñéw wórds évérÿ sìñglé dàÿ wìth óûr àmàzìñg àpplìcàtìón !!!]";
+"home.todayWord" = "[!!! Tódàÿ's Spécìàl Wórd !!!]";
+"home.startQuiz" = "[!!! Stàrt Yóûr Qûìz Nów !!!]";
+"home.studyCount" = "[!!! Wórds Stûdìéd: %d ítéms !!!]";
+"home.streakCount" = "[!!! Stûdÿ Strèàk: %d cóñsècûtìvé dàÿs !!!]";
+
+// MARK: - 퀴즈 화면 (Quiz Screen) - Various length strings
+"quiz.title" = "[!!! Wórd Qûìz Chàlléñgé !!!]";
+"quiz.question" = "[!!! Qûéstìón %d óût óf %d tótàl !!!]";
+"quiz.nextButton" = "[!!! Próçééd tó Néxt !!!]";
+"quiz.submitButton" = "[!!! Sûbmìt Äñswér !!!]";
+"quiz.finishButton" = "[!!! Fìñìsh Qûìz !!!]";
+"quiz.correct" = "[!!! Córréct Äñswér! Éxçélléñt! !!!]";
+"quiz.incorrect" = "[!!! Ìñcórréct. Trÿ àgàìñ. !!!]";
+"quiz.correctAnswer" = "[!!! Thé córréct àñswér ìs: %@ !!!]";
+"quiz.score" = "[!!! Yóûr cûrréñt scóré: %d póìñts !!!]";
+"quiz.completion" = "[!!! Qûìz Cómplétéd Sûccéssfûllÿ! !!!]";
+"quiz.totalScore" = "[!!! Tótàl Fìñàl Scóré: %d óût óf %d !!!]";
+"quiz.restartButton" = "[!!! Réstàrt Qûìz Frôm Bégìññìñg !!!]";
+"quiz.homeButton" = "[!!! Gó Bàck tó Hómé !!!]";
+
+// MARK: - 설정 화면 (Settings Screen) - Mixed length strings
+"settings.title" = "[!!! Äpplìcàtìón Séttìñgs !!!]";
+"settings.notification" = "[!!! Nótìfìcàtìón Préférénçés !!!]";
+"settings.language" = "[!!! Làñgûàgé Séléçtìón !!!]";
+"settings.theme" = "[!!! Äpplìcàtìón Théme !!!]";
+"settings.about" = "[!!! Äbóût Thìs Äpp !!!]";
+"settings.version" = "[!!! Vérśìón Ìñfórmàtìón !!!]";
+"settings.contact" = "[!!! Cóñtàct Sûppórt !!!]";
+"settings.privacy" = "[!!! Prìvàçÿ Pólìçÿ !!!]";
+"settings.terms" = "[!!! Térms óf Sérvìçé !!!]";
+
+// MARK: - 알림 설정 (Notification Settings) - Long descriptive strings
+"notification.title" = "[!!! Nótìfìcàtìón Séttìñgs Màñàgémént !!!]";
+"notification.daily" = "[!!! Dàìlÿ Nótìfìcàtìón Rémìñdérs !!!]";
+"notification.time" = "[!!! Nótìfìcàtìón Tìmé Sçhédûlé !!!]";
+"notification.sound" = "[!!! Nótìfìcàtìón Sóûñd Séléçtìón !!!]";
+"notification.permission.title" = "[!!! Nótìfìcàtìón Pérmìssìón Réqûìréd !!!]";
+"notification.permission.message" = "[!!! Pléàsé àllów nótìfìcàtìóns tó réçéìvé dàìlÿ wórd qûìz rémìñdérs àñd stàÿ éñgàgéd wìth yóûr léàrñìñg jóûrñéÿ. !!!]";
+"notification.permission.settings" = "[!!! Öpéñ Séttìñgs Äpplìcàtìón !!!]";
+
+// MARK: - 오류 메시지 (Error Messages) - Critical messages
+"error.network" = "[!!! Pléàsé chéck yóûr ñétwórk çóññéçtìón àñd trÿ àgàìñ. !!!]";
+"error.unknown" = "[!!! Äñ ûñkñówñ érrór óççûrréd. Pléàsé réstàrt thé àpplìcàtìón. !!!]";
+"error.dataLoad" = "[!!! Äñ érrór óççûrréd whìlé lóàdìñg dàtà fróm thé sérvér. !!!]";
+"error.permission" = "[!!! Spéçìàl pérmìssìón ìs réqûìréd tó àççéss thìs féàtûré. !!!]";
+
+// MARK: - 성공 메시지 (Success Messages) - Positive feedback
+"success.save" = "[!!! Dàtà hàs béèñ sàvéd sûççéssfûllÿ! !!!]";
+"success.update" = "[!!! Ìñfórmàtìón hàs béèñ ûpdàtéd sûççéssfûllÿ! !!!]";
+"success.delete" = "[!!! Ìtém hàs béèñ délétéd sûççéssfûllÿ! !!!]";
+
+// MARK: - 단어 관련 (Word Related) - Educational content
+"word.meaning" = "[!!! Wórd Méàñìñg Éxplàñàtìón !!!]";
+"word.pronunciation" = "[!!! Próñûñçìàtìón Gûìdé !!!]";
+"word.example" = "[!!! Éxàmplé Séñténçé !!!]";
+"word.difficulty" = "[!!! Dìffìçûltÿ Lévél !!!]";
+"word.category" = "[!!! Wórd Càtégórÿ !!!]";
+"word.bookmark" = "[!!! Bóókmàrk Fàvórìté !!!]";
+"word.learned" = "[!!! Léàrñìñg Cómplétéd !!!]";
+"word.learning" = "[!!! Cûrréñtlÿ Léàrñìñg !!!]";
+"word.notStarted" = "[!!! Nót Stàrtéd Yét !!!]";

--- a/WordQuizDaily/WordQuizDaily/Views/Home/HomeView.swift
+++ b/WordQuizDaily/WordQuizDaily/Views/Home/HomeView.swift
@@ -49,7 +49,7 @@ struct HomeView: View {
                 Spacer()
                 
             }
-            .navigationTitle("오늘의 단어")
+            .navigationTitle(LocalizedStringKey(LocalizationKeys.Home.todayWord))
 
         }
         .onReceive(homeViewModel.$toDayWordDefinition) { _ in
@@ -62,4 +62,27 @@ struct HomeView: View {
 #Preview {
     HomeView()
         .environmentObject(HomeViewModel())
+        .previewLocale("ko")
+}
+
+// MARK: - 다국어 프리뷰
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            HomeView()
+                .environmentObject(HomeViewModel())
+                .previewLocale("ko")
+                .previewDisplayName("Korean")
+            
+            HomeView()
+                .environmentObject(HomeViewModel())
+                .previewLocale("en")
+                .previewDisplayName("English")
+            
+            HomeView()
+                .environmentObject(HomeViewModel())
+                .previewLocale("ja")
+                .previewDisplayName("Japanese")
+        }
+    }
 }

--- a/WordQuizDaily/WordQuizDaily/Views/Quiz/QuizView.swift
+++ b/WordQuizDaily/WordQuizDaily/Views/Quiz/QuizView.swift
@@ -29,7 +29,7 @@ struct QuizView: View {
                 }
                 Spacer()
             }
-            .navigationTitle("단어 퀴즈")
+            .navigationTitle(LocalizedStringKey(LocalizationKeys.Quiz.title))
 
         }
     }
@@ -43,7 +43,7 @@ struct answerImageView: View {
         
         VStack {
             if quizViewModel.isLoading {
-                ProgressView("Loading...")
+                ProgressView(LocalizedStringKey(LocalizationKeys.Quiz.loadingImages))
                     .frame(maxWidth: UIScreen.main.bounds.width * 0.8, minHeight: 200, maxHeight: 200, alignment: .center)
             } else {
                 if let imageData = quizViewModel.imageData {
@@ -109,7 +109,7 @@ struct ChoiceView: View {
                         if isAnswerCorrect {
                             quizViewModel.fetchData()
                         }
-                        print("선택된 단어: \(word), 정답?: \(isAnswerCorrect)")
+                        print("\(LocalizationKeys.Quiz.selectedWord.localized): \(word), \(LocalizationKeys.Quiz.isCorrect.localized)?: \(isAnswerCorrect)")
                     }
                 }) {
                     HStack {
@@ -138,7 +138,20 @@ struct ChoiceView: View {
 }
 
 
-#Preview {
+#Preview("한국어") {
     QuizView()
         .environmentObject(QuizViewModel())
+        .previewLocale("ko")
+}
+
+#Preview("English") {
+    QuizView()
+        .environmentObject(QuizViewModel())
+        .previewLocale("en")
+}
+
+#Preview("日本語") {
+    QuizView()
+        .environmentObject(QuizViewModel())
+        .previewLocale("ja")
 }

--- a/WordQuizDaily/WordQuizDaily/Views/Setting/SettingView.swift
+++ b/WordQuizDaily/WordQuizDaily/Views/Setting/SettingView.swift
@@ -1,5 +1,5 @@
 //
-//  NotificationView.swift
+//  SettingView.swift
 //  WordQuizDaily
 //
 //  Created by 정종원 on 1/24/24.
@@ -21,14 +21,14 @@ struct SettingView: View {
             VStack(alignment: .leading, spacing: 10){
                 Form{
                     //알림 설정 ex) 푸시알림, 효과음
-                    Section(header: Text("알림 설정").font(.caption)) {
+                    Section(header: Text(LocalizedStringKey(LocalizationKeys.Settings.notificationSection)).font(.caption)) {
                         //NotiView
                         NotiView()
                         
                     }
                     //개인정보 보호 설정...?
-                    Section(header: Text("기타 설정").font(.caption)) {
-                        Button("서비스 약관") {
+                    Section(header: Text(LocalizedStringKey(LocalizationKeys.Settings.otherSection)).font(.caption)) {
+                        Button(LocalizedStringKey(LocalizationKeys.Settings.termsOfService)) {
                             isShowTermsOfService = true
                         }
                         .foregroundStyle(.black)
@@ -36,7 +36,7 @@ struct SettingView: View {
                             TermsofServiceView()
                         })
                         
-                        Button("앱 버전") {
+                        Button(LocalizedStringKey(LocalizationKeys.Settings.appVersion)) {
                             isShowAppVersion = true
                         }
                         .foregroundStyle(.black)
@@ -44,7 +44,7 @@ struct SettingView: View {
                             AppVersionView()
                         })
                         
-                        Button("고객 지원") {
+                        Button(LocalizedStringKey(LocalizationKeys.Settings.customerService)) {
                             isShowCustomerService = true
                         }
                         .foregroundStyle(.black)
@@ -52,7 +52,7 @@ struct SettingView: View {
                             CustomerServiceView()
                         })
                         
-                        Button("피드백") {
+                        Button(LocalizedStringKey(LocalizationKeys.Settings.feedback)) {
                             isShowFeedback = true
                         }
                         .foregroundStyle(.black)
@@ -65,7 +65,7 @@ struct SettingView: View {
                 
                 
             }
-            .navigationTitle("Setting")
+            .navigationTitle(LocalizedStringKey(LocalizationKeys.Settings.title))
             
         } //NavigationStack
     }
@@ -80,7 +80,7 @@ struct NotiView: View {
         VStack(alignment: .leading){
             
             HStack {
-                Text("푸시 알림")
+                Text(LocalizedStringKey(LocalizationKeys.Settings.pushNotification))
                 if notificationManager.isToggleOn {
                     DatePicker("", selection: $notificationManager.notificationTime, displayedComponents: .hourAndMinute)
                         .datePickerStyle(.graphical)
@@ -99,9 +99,14 @@ struct NotiView: View {
             } //HStack
             .alert(isPresented: $notificationManager.isAlertOccurred) {
                 //알림 설정이 꺼져있을 경우 설정창으로 이동
-                Alert(title:Text("Notification Alert"), message: Text("알림 설정이 꺼져있습니다. 설정에서 알림을 켜주세요."), primaryButton: .cancel(Text("이동"), action: {
-                    notificationManager.openSettings()
-                }), secondaryButton: .destructive(Text("Cancel")))
+                Alert(
+                    title: Text(LocalizedStringKey(LocalizationKeys.Notification.alertTitle)), 
+                    message: Text(LocalizedStringKey(LocalizationKeys.Notification.alertMessage)), 
+                    primaryButton: .cancel(Text(LocalizedStringKey(LocalizationKeys.Notification.alertGoToSettings)), action: {
+                        notificationManager.openSettings()
+                    }), 
+                    secondaryButton: .destructive(Text(LocalizedStringKey(LocalizationKeys.Common.cancel)))
+                )
             }
             .onTapGesture {
                 if notificationManager.isToggleOn {
@@ -117,56 +122,13 @@ struct TermsofServiceView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("서비스 약관")
+            Text(LocalizedStringKey(LocalizationKeys.TermsOfService.title))
                 .font(.title)
                 .padding(.bottom, 10)
             
             ScrollView {
-                Text("""
-                        최종 수정일: 2024년 07월 01일
-                        
-                        1. 개요
-                        이 서비스 약관("약관")은 WordQuizDaily("앱")의 이용에 관한 법적 조건을 명시합니다. 개인 개발자인 정종원에 의해 제공되며, 사용자는 앱을 다운로드하거나 사용함으로써 이 약관에 동의하는 것으로 간주됩니다.
-                        
-                        2. 서비스 이용
-                        2.1 허용된 사용: 사용자는 앱을 법적 목적으로만 사용해야 합니다. 불법적인 활동이나 당사의 정책을 위반하는 행위는 엄격히 금지됩니다.
-                        2.2 제한된 사용: 사용자는 앱을 해킹, 스팸 발송, 바이러스 유포 등의 방식으로 사용할 수 없습니다. 당사는 사용자의 앱 접근을 제한할 권리를 가집니다.
-                        
-                        3. API 사용
-                        3.1 외부 API: 본 앱은 네이버 이미지 검색 API와 우리말샘 단어 검색 API를 사용합니다. 사용자는 해당 API 제공자의 이용 약관을 준수해야 합니다.
-                        
-                        4. 콘텐츠
-                        4.1 사용자 콘텐츠: 사용자는 앱에 업로드하거나 게시한 모든 콘텐츠에 대한 권리를 보유합니다. 그러나 사용자는 당사에 해당 콘텐츠를 앱 내에서 사용할 수 있는 비독점적, 영구적, 취소 불가능한 권리를 부여합니다.
-                        4.2 금지된 콘텐츠: 사용자는 명예 훼손, 음란물, 폭력, 증오 발언 등을 포함한 불법적인 콘텐츠를 게시할 수 없습니다.
-                        
-                        5. 개인정보 보호
-                        5.1 개인정보 수집: 본 앱은 로그인이 필요하지 않습니다. 사용자의 개인정보는 수집되지 않으며, 따라서 별도의 개인정보 처리방침은 없습니다.
-                        
-                        6. 제3자 서비스
-                        앱은 제3자 서비스나 콘텐츠를 포함할 수 있습니다. 당사는 제3자 서비스에 대해 책임지지 않으며, 사용자는 해당 제3자 서비스의 약관을 준수해야 합니다.
-                        
-                        7. 면책 조항
-                        앱은 "있는 그대로" 제공되며, 당사는 앱의 정확성, 신뢰성, 완전성에 대해 보증하지 않습니다. 사용자는 앱 사용에 따른 모든 위험을 감수해야 합니다.
-                        
-                        8. 책임 제한
-                        법이 허용하는 최대 한도 내에서, 당사는 앱 사용과 관련된 직간접적 손해에 대해 책임지지 않습니다.
-                        
-                        9. 약관의 변경
-                        당사는 언제든지 이 약관을 수정할 권리를 가집니다. 변경 사항은 앱 내에 게시되며, 사용자는 변경된 약관에 동의하는 것으로 간주됩니다.
-                        
-                        10. 종료
-                        당사는 사용자가 이 약관을 위반하는 경우 언제든지 사전 통보 없이 사용자의 앱 접근을 종료할 수 있습니다.
-                        
-                        11. 준거법 및 분쟁 해결
-                        이 약관은 대한민국 법에 따라 해석되며, 약관과 관련된 모든 분쟁은 대한민국의 법원에 전속 관할권이 있습니다.
-                        
-                        12. 연락처 정보
-                        약관에 관한 질문은 아래 연락처로 문의해 주십시오:
-                        
-                        정종원
-                        이메일: jjwon2149@gmail.com
-                        """)
-                .padding()
+                Text(LocalizedStringKey(LocalizationKeys.TermsOfService.content))
+                    .padding()
             }
         }
         .padding()
@@ -178,18 +140,15 @@ struct AppVersionView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("앱 버전")
+            Text(LocalizedStringKey(LocalizationKeys.AppVersion.title))
                 .font(.title)
                 .padding(.bottom, 10)
             
-            Text("현재 버전: 1.0.0")
+            Text(LocalizedStringKey(LocalizationKeys.AppVersion.currentVersion))
                 .padding(.bottom, 5)
             
-            Text("""
-                업데이트 내역:
-                - 버전 1.0.0: 최초 릴리즈
-                """)
-            .padding()
+            Text(LocalizedStringKey(LocalizationKeys.AppVersion.updateHistory))
+                .padding()
         }
         .padding()
     }
@@ -200,31 +159,28 @@ struct CustomerServiceView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("고객 지원")
+            Text(LocalizedStringKey(LocalizationKeys.CustomerService.title))
                 .font(.title)
                 .padding(.bottom, 10)
             
-            Text("""
-                고객 지원 문의:
-                - 이메일: jjwon2149@gmail.com
-                """)
-            .padding()
+            Text(LocalizedStringKey(LocalizationKeys.CustomerService.contactInfo))
+                .padding()
             
-            Text("자주 묻는 질문")
+            Text(LocalizedStringKey(LocalizationKeys.CustomerService.faq))
                 .font(.headline)
                 .padding(.top, 10)
             
-            Text("""
-                Q: 비밀번호를 잊어버렸어요.
-                A: 이 앱은 로그인이 없는디용
+            VStack(alignment: .leading, spacing: 5) {
+                Text(LocalizedStringKey(LocalizationKeys.CustomerService.faqPassword))
+                Text(LocalizedStringKey(LocalizationKeys.CustomerService.faqPasswordAnswer))
+                    .padding(.bottom, 10)
                 
-                Q: 앱이 제대로 작동하지 않아요.
-                A: 앱을 재설치하거나 최신 버전으로 업데이트해보세요. 그래도 문제가 해결되지 않으면 고객 지원에 문의하세요.
-                """)
+                Text(LocalizedStringKey(LocalizationKeys.CustomerService.faqNotWorking))
+                Text(LocalizedStringKey(LocalizationKeys.CustomerService.faqNotWorkingAnswer))
+            }
             .padding()
-            
-            
         }
+        .padding()
     }
 }
 
@@ -233,23 +189,34 @@ struct FeedBackView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("피드백")
+            Text(LocalizedStringKey(LocalizationKeys.Feedback.title))
                 .font(.title)
                 .padding(.bottom, 10)
             
-            Text("""
-                앱 사용 중 불편한 점이나 개선사항이 있다면 언제든지 피드백을 보내주세요. 여러분의 의견은 저희에게 큰 도움이 됩니다.
-                
-                피드백 보내기:
-                - 이메일: jjwon2149@gmail.com
-                - 날카로운 지적 해주시면 바로 반영 하겠습니다 ^_^
-                """)
-            .padding()
+            Text(LocalizedStringKey(LocalizationKeys.Feedback.content))
+                .padding(.bottom, 10)
+            
+            Text(LocalizedStringKey(LocalizationKeys.Feedback.contactInfo))
+                .padding()
         }
+        .padding()
     }
 }
 
-#Preview {
+#Preview("한국어") {
     SettingView()
         .environmentObject(FCMNotificationManager())
+        .previewLocale("ko")
+}
+
+#Preview("English") {
+    SettingView()
+        .environmentObject(FCMNotificationManager())
+        .previewLocale("en")
+}
+
+#Preview("日本語") {
+    SettingView()
+        .environmentObject(FCMNotificationManager())
+        .previewLocale("ja")
 }


### PR DESCRIPTION
## 📝 변경 사항 요약
WordQuizDaily 앱에 다국어 지원 기능을 추가했습니다. 한국어, 영어, 일본어를 지원하며, iOS 16 이상에서의 호환성을 개선했습니다.

**주요 변경사항:**
- 3개 언어(ko, en, ja) 로컬라이제이션 파일 추가
- iOS 16+ 언어 코드 가져오기 방식 개선 
- UI 컴포넌트들의 다국어 대응
- 의사 로컬라이제이션(pseudo-localization)으로 UI 레이아웃 테스트 지원
- Xcode 런치 액션 언어 설정 최적화

## 🎯 변경 유형
<!-- 해당되는 항목에 [x]를 표시해주세요 -->
- [ ] 🐛 버그 수정 (Bug fix)
- [x] ✨ 새로운 기능 (New feature)
- [x] 🔧 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [x] 🎨 UI/UX 개선 (UI/UX improvement)
- [x] ⚡ 성능 개선 (Performance improvement)
- [ ] 🔒 보안 강화 (Security enhancement)
- [ ] 🧪 테스트 추가/수정 (Test)

## 🔍 변경된 파일
### 🌍 로컬라이제이션 파일
- `WordQuizDaily/Resources/Localizations/ko.lproj/Localizable.strings` (125 keys)
- `WordQuizDaily/Resources/Localizations/en.lproj/Localizable.strings` (187 keys)
- `WordQuizDaily/Resources/Localizations/ja.lproj/Localizable.strings` (196 keys)
- `WordQuizDaily/Resources/Localizations/ko.lproj/InfoPlist.strings`
- `WordQuizDaily/Resources/Localizations/en.lproj/InfoPlist.strings`
- `WordQuizDaily/Resources/Localizations/ja.lproj/InfoPlist.strings`
- `WordQuizDaily/Resources/Localizations/pseudo.lproj/Localizable.strings` (테스트용)

### 🛠️ 헬퍼 및 유틸리티
- `WordQuizDaily/Helpers/LocalizationHelper.swift` (새로 추가)
- `WordQuizDaily/Helpers/FormatterUtils.swift` (새로 추가)

### 📱 UI 컴포넌트
- `WordQuizDaily/Views/Home/HomeView.swift`
- `WordQuizDaily/Views/Quiz/QuizView.swift`
- `WordQuizDaily/Views/Setting/SettingView.swift`
- `WordQuizDaily/ContentView.swift`

### ⚙️ 프로젝트 설정
- `WordQuizDaily.xcodeproj/project.pbxproj`
- `WordQuizDaily.xcodeproj/xcshareddata/xcschemes/WordQuizDaily.xcscheme`

## 📱 테스트 환경
<!-- 테스트한 환경을 체크해주세요 -->
- [x] iOS Simulator (iPhone 13 Pro, iOS 17)
- [ ] 실제 디바이스 (기종: )
- [ ] Unit Tests 통과
- [ ] UI Tests 통과

## 📸 스크린샷 (선택사항)
### 🇺🇸 영어
<img width="300" height="2340" alt="Simulator Screenshot - iPhone 13 mini - 2025-07-22 at 00 24 54" src="https://github.com/user-attachments/assets/34ffb2b7-7989-41d2-bca2-fb865a33a587" />

### 🇯🇵 일본어
<img width="300" height="2340" alt="Simulator Screenshot - iPhone 13 mini - 2025-07-22 at 00 24 05" src="https://github.com/user-attachments/assets/e51a8254-3e2e-4782-931e-502cd7a5aed8" />


## 🔧 기술적 세부사항
### 로컬라이제이션 구현
- **LocalizationHelper.swift**: 타입 안전한 로컬라이제이션 키 관리 시스템
- **FormatterUtils.swift**: 다국어 숫자/날짜 포맷팅 유틸리티
- **iOS 16+ 호환성**: `Locale.current.language.languageCode?.identifier` 사용으로 deprecation 경고 해결

### 지원 언어
- **한국어 (ko)**: 기본 언어, 125개 키
- **영어 (en)**: 187개 키 (추가 UI 텍스트 포함)
- **일본어 (ja)**: 196개 키 (가장 포괄적인 번역)
- **Pseudo**: 테스트용 의사 로컬라이제이션

### UI 개선사항
- 모든 하드코딩된 문자열을 로컬라이제이션 키로 변경
- SwiftUI Preview에서 다국어 미리보기 지원
- 언어별 UI 레이아웃 최적화

## ✅ 체크리스트
<!-- PR 제출 전 확인사항 -->
- [x] 코드가 정상적으로 빌드됩니다
- [x] 기존 기능에 영향을 주지 않습니다
- [x] 새로운 기능에 대한 테스트가 추가되었습니다 (해당하는 경우)
- [ ] 문서가 업데이트되었습니다 (해당하는 경우)
- [x] 코드 리뷰 가이드라인을 준수했습니다

### 🌍 로컬라이제이션 체크리스트
- [x] 모든 UI 텍스트가 로컬라이제이션됨
- [x] InfoPlist.strings로 앱 이름 다국어 대응
- [x] iOS 16+ deprecated API 대응
- [x] 의사 로컬라이제이션으로 UI 레이아웃 테스트
- [ ] 실기기에서 언어별 테스트 완료
- [ ] 네이티브 스피커 번역 검토 완료

## 📚 추가 정보

### ⚠️ 알려진 제한사항
- SwiftUI의 런타임 언어 변경 제한으로 인해 언어 변경 시 앱 재시작 필요
- 일부 복잡한 문장 구조는 추가 현지화 작업 필요

### 🎯 다음 단계
1. 실기기 테스트 및 QA
2. 앱스토어 메타데이터 다국어 작성
3. 스크린샷 각 언어별 촬영
4. TestFlight 배포 및 사용자 피드백 수집

## 🔗 관련 이슈
Relates to: 다국어 지원 기능 구현
